### PR TITLE
fix 8769 plural descriptions

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -51,7 +51,7 @@ class AudioTrackMenuItem extends MenuItem {
     const el = super.createEl(type, props, attrs);
     const parentSpan = el.querySelector('.vjs-menu-item-text');
 
-    if (['main-desc', 'descriptionS'].indexOf(this.options_.track.kind) >= 0) {
+    if (['main-desc', 'descriptions'].indexOf(this.options_.track.kind) >= 0) {
       parentSpan.appendChild(Dom.createEl('span', {
         className: 'vjs-icon-placeholder'
       }, {

--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -51,7 +51,7 @@ class AudioTrackMenuItem extends MenuItem {
     const el = super.createEl(type, props, attrs);
     const parentSpan = el.querySelector('.vjs-menu-item-text');
 
-    if (['main-desc', 'description'].indexOf(this.options_.track.kind) >= 0) {
+    if (['main-desc', 'descriptionS'].indexOf(this.options_.track.kind) >= 0) {
       parentSpan.appendChild(Dom.createEl('span', {
         className: 'vjs-icon-placeholder'
       }, {


### PR DESCRIPTION
## Description
Fix #8769 for mismatched track kind should be plural descriptions according to definition of `AudioTrackKind`
https://github.com/videojs/video.js/issues/8769

## Specific Changes proposed
Pluralisation

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
